### PR TITLE
Reset production gem settings

### DIFF
--- a/youta/Gemfile
+++ b/youta/Gemfile
@@ -29,7 +29,3 @@ group :test do
   gem 'factory_girl_rails', '4.2.1'
 end
 
-group :production do
-  gem 'pg',             '0.17.1'
-  gem 'rails_12factor', '0.0.2'
-end

--- a/youta/Gemfile.lock
+++ b/youta/Gemfile.lock
@@ -141,7 +141,6 @@ GEM
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pg (0.17.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -170,11 +169,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.2)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.4)
     railties (4.2.2)
       actionpack (= 4.2.2)
       activesupport (= 4.2.2)
@@ -261,10 +255,8 @@ DEPENDENCIES
   jquery-rails (= 4.0.3)
   mini_backtrace (= 0.1.3)
   minitest-reporters (= 1.0.5)
-  pg (= 0.17.1)
   pry-rails
   rails (= 4.2.2)
-  rails_12factor (= 0.0.2)
   rspec-rails (= 3.1)
   sass-rails (= 5.0.2)
   sdoc (= 0.4.0)


### PR DESCRIPTION
GemのProduction設定がheroku用になってる(RailsTutorialのまま)ので消す